### PR TITLE
Fix compatibility of conftest.py with Astropy 3.2

### DIFF
--- a/astropy_healpix/conftest.py
+++ b/astropy_healpix/conftest.py
@@ -1,61 +1,12 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-# this contains imports plugins that configure py.test for astropy tests.
-# by importing them here in conftest.py they are discoverable by py.test
-# no matter how it is invoked within the source tree.
-
-from astropy.tests.pytest_plugins import *
-
-# Uncomment the following line to treat all DeprecationWarnings as
-# exceptions. For Astropy v2.0 or later, there are 2 additional keywords,
-# as follow (although default should work for most cases).
-# To ignore some packages that produce deprecation warnings on import
-# (in addition to 'compiler', 'scipy', 'pygments', 'ipykernel', and
-# 'setuptools'), add:
-#     modules_to_ignore_on_import=['module_1', 'module_2']
-# To ignore some specific deprecation warning messages for Python version
-# MAJOR.MINOR or later, add:
-#     warnings_to_ignore_by_pyver={(MAJOR, MINOR): ['Message to ignore']}
-enable_deprecations_as_exceptions()
-
-# Uncomment and customize the following lines to add/remove entries from
-# the list of packages for which version numbers are displayed when running
-# the tests. Making it pass for KeyError is essential in some cases when
-# the package uses other astropy affiliated packages.
-try:
-    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
-    PYTEST_HEADER_MODULES['healpy'] = 'healpy'
-    PYTEST_HEADER_MODULES['Cython'] = 'cython'
-    del PYTEST_HEADER_MODULES['h5py']
-    del PYTEST_HEADER_MODULES['Pandas']
-except (NameError, KeyError):  # NameError is needed to support Astropy < 1.0
-    pass
-
-# Uncomment the following lines to display the version number of the
-# package rather than the version number of Astropy in the top line when
-# running the tests.
-import os
-
-# This is to figure out the affiliated package version, rather than
-# using Astropy's
-try:
-    from .version import version
-except ImportError:
-    version = 'dev'
-
-try:
-    packagename = os.path.basename(os.path.dirname(__file__))
-    TESTED_VERSIONS[packagename] = version
-except NameError:   # Needed to support Astropy <= 1.0.0
-    pass
-
-def pytest_configure():
-    """Set the Numpy print style to a fixed version to make doctest outputs
-    reproducible."""
-    import numpy as np
-    try:
-        np.set_printoptions(legacy='1.13')
-    except TypeError:
-        # On older versions of Numpy, the unrecognized 'legacy' option will
-        # raise a TypeError.
-        pass
+from astropy.version import version as astropy_version
+if astropy_version < '3.0':
+    # With older versions of Astropy, we actually need to import the pytest
+    # plugins themselves in order to make them discoverable by pytest.
+    from astropy.tests.pytest_plugins import *
+else:
+    # As of Astropy 3.0, the pytest plugins provided by Astropy are
+    # automatically made available when Astropy is installed. This means it's
+    # not necessary to import them here, but we still need to import global
+    # variables that are used for configuration.
+    from astropy.tests.plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS


### PR DESCRIPTION
### :page_with_curl: About this pull request

Hi there :wave:, it looks like you likely used the astropy package template in the past for your package and we noticed that your conftest.py file is now out of date and imports pytest plugins from astropy:

```python
from astropy.tests.pytest_plugins import *
```

This astropy sub-package has been removed, so your tests will likely be failing now that astropy v3.2 has been released. This PR therefore fixes this import by checking the astropy version and adjusting the import as needed.

### :loudspeaker: For info: updates to the package template

We also wanted to let you know that we have made new releases of the astropy package-template. If your package still needs to support Python 2, you can find the latest [Python 2-compatible cookiecutter template here](https://github.com/astropy/package-template/tree/cookiecutter-2.x) or if you prefer you can find a [rendered version of the template here](https://github.com/astropy/package-template/tree/master-py2).

If you only need to support Python 3, you can find the latest [cookiecutter template here](https://github.com/astropy/package-template) or if you prefer you can find a [rendered version of the template here](https://github.com/astropy/package-template/tree/master).

If you need any help with updating your package to the latest package template, don't hesitate to ping @astrofrog or @bsipocz and we can try and help.

If you do not want to make this change for now, feel free to close the pull request

Thanks! :robot: :wave:

*If there are issues with this pull request, please ping ``@astrofrog``*